### PR TITLE
[Feat/#24] 응답자 수 필터 단일선택 제약 추가 및 레이블 수정

### DIFF
--- a/src/components/home/filter-section.tsx
+++ b/src/components/home/filter-section.tsx
@@ -10,6 +10,7 @@ interface FilterSectionProps {
   }[];
   onSelectionChange?: (selectedCodes: number[]) => void;
   reset?: number;
+  singleSelect?: boolean;
 }
 
 export default function FilterSection({
@@ -17,6 +18,7 @@ export default function FilterSection({
   chips,
   onSelectionChange,
   reset = 0, // 필터 초기화 오류로 인해 숫자형식으로 reset 값이 변경되었을 때 초기화 실행
+  singleSelect = false,
 }: FilterSectionProps) {
   const [selectedChips, setSelectedChips] = useState<number[]>([]);
   const prevResetValueRef = useRef<number | undefined>(reset);
@@ -37,12 +39,22 @@ export default function FilterSection({
   }, [reset]);
 
   const handleChipClick = (id: number) => {
-    let newSelectedChips;
-    if (selectedChips.includes(id)) {
-      newSelectedChips = selectedChips.filter((chip) => chip !== id);
+    let newSelectedChips: number[];
+
+    if (singleSelect) {
+      if (selectedChips.includes(id)) {
+        newSelectedChips = [];
+      } else {
+        newSelectedChips = [id];
+      }
     } else {
-      newSelectedChips = [...selectedChips, id];
+      if (selectedChips.includes(id)) {
+        newSelectedChips = selectedChips.filter((chip) => chip !== id);
+      } else {
+        newSelectedChips = [...selectedChips, id];
+      }
     }
+
     setSelectedChips(newSelectedChips);
 
     // 선택된 칩들의 code를 배열로 추출

--- a/src/data/filter-sectioins.ts
+++ b/src/data/filter-sectioins.ts
@@ -2,6 +2,7 @@ export const filterSections = [
   {
     id: 1,
     title: "응답자 수",
+    singleSelect: true,
     chips: [
       {
         id: 1,

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -236,6 +236,7 @@ export default function Home() {
                     handleSectionSelectionChange(index, selectedCodes)
                   }
                   reset={resetTrigger}
+                  singleSelect={section.singleSelect}
                 />
               ))}
             </div>


### PR DESCRIPTION
## ✨ 작업 개요

<!-- 어떤 기능을 구현했는지 간단히 설명해주세요. -->
응답자 수 필터 단일선택 제약 추가 및 레이블 수정

## 📌 관련 이슈

- close #24 

## ✅ 작업 내용
응답자 수 필터 레이블이 연령으로 되어있어서 수정 했고,
단일 선택으로 제약 추가 했습니다!

## 📷 UI 스크린샷 (해당 시)
<img width="406" height="104" alt="image" src="https://github.com/user-attachments/assets/bdcededb-9725-4fdf-ae59-635a193503ef" />


## 💬 기타 사항

<!-- 리뷰어가 알면 좋을 내용이 있다면 적어주세요 -->
